### PR TITLE
Fixes CSS-display problems with HTTPS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,5 +6,5 @@ title: Lightweight Modular Staging
 tagline: Program Generation and Embedded Compilers in Scala
 github_url: https://github.com/TiarkRompf/virtualization-lms-core
 
-production_url : http://scala-lms.github.com
-baseurl: http://scala-lms.github.com/
+production_url : https://scala-lms.github.com
+baseurl: https://scala-lms.github.com/


### PR DESCRIPTION
Modern browsers denying to load the referenced resources (here CSS and JS) with HTTP if the referring page was loaded with HTTPS and complaining about "mixed content".

This happens if you visit https://scala-lms.github.io/ as suggested by some search engines.

Referring HTTPS resources from a HTTP page cause no problems. So visiting http://scala-lms.github.io/ shouldn't cause any problems.
