### PR TITLE
Fix Mixed-Content errors when using HTTPS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,5 +6,5 @@ title: Lightweight Modular Staging
 tagline: Program Generation and Embedded Compilers in Scala
 github_url: https://github.com/TiarkRompf/virtualization-lms-core
 
-production_url : https://scala-lms.github.com
-baseurl: https://scala-lms.github.com/
+production_url : https://scala-lms.github.io
+baseurl: https://scala-lms.github.io/


### PR DESCRIPTION
Before this commit, https://scala-lms.github.io/ was broken because
the generated pages contained links to
"https://scala-lms.github.com/..." which are 301-redirected to
"http://scala-lms.github.io/..." and modern browsers refuse to load HTTP
resources in HTTPS pages. The fix is to make sure that the links all
start with "https://scala-lms.github.io/..." so that no redirects-to-HTTP happen.